### PR TITLE
Fix GPIO direct access

### DIFF
--- a/sming/libraries/Adafruit_PCD8544/Adafruit_PCD8544.h
+++ b/sming/libraries/Adafruit_PCD8544/Adafruit_PCD8544.h
@@ -4,14 +4,14 @@ This is a library for our Monochrome Nokia 5110 LCD Displays
   Pick one up today in the adafruit shop!
   ------> http://www.adafruit.com/products/338
 
-These displays use SPI to communicate, 4 or 5 pins are required to  
+These displays use SPI to communicate, 4 or 5 pins are required to
 interface
 
-Adafruit invests time and resources providing this open source code, 
-please support Adafruit and open-source hardware by purchasing 
+Adafruit invests time and resources providing this open source code,
+please support Adafruit and open-source hardware by purchasing
 products from Adafruit!
 
-Written by Limor Fried/Ladyada  for Adafruit Industries.  
+Written by Limor Fried/Ladyada  for Adafruit Industries.
 BSD license, check license.txt for more information
 All text above, and the splash screen must be included in any redistribution
 *********************************************************************/
@@ -31,6 +31,9 @@ All text above, and the splash screen must be included in any redistribution
 #ifdef __SAM3X8E__
  typedef volatile RwReg PortReg;
  typedef uint32_t PortMask;
+#elif defined (__ESP8266_EX__)
+  typedef volatile GPIO_REG_TYPE PortReg;
+  typedef GPIO_REG_TYPE PortMask;
 #else
   typedef volatile uint8_t PortReg;
   typedef uint8_t PortMask;
@@ -79,14 +82,14 @@ class Adafruit_PCD8544 : public Adafruit_GFX {
   Adafruit_PCD8544(int8_t DC, int8_t CS, int8_t RST);
 
   void begin(uint8_t contrast = 40, uint8_t bias = 0x04);
-  
+
   void command(uint8_t c);
   void data(uint8_t c);
-  
+
   void setContrast(uint8_t val);
   void clearDisplay(void);
   void display();
-  
+
   void drawPixel(int16_t x, int16_t y, uint16_t color);
   uint8_t getPixel(int8_t x, int8_t y);
 

--- a/sming/libraries/Adafruit_SSD1306/Adafruit_SSD1306.h
+++ b/sming/libraries/Adafruit_SSD1306/Adafruit_SSD1306.h
@@ -4,14 +4,14 @@ This is a library for our Monochrome OLEDs based on SSD1306 drivers
   Pick one up today in the adafruit shop!
   ------> http://www.adafruit.com/category/63_98
 
-These displays use SPI to communicate, 4 or 5 pins are required to  
+These displays use SPI to communicate, 4 or 5 pins are required to
 interface
 
-Adafruit invests time and resources providing this open source code, 
-please support Adafruit and open-source hardware by purchasing 
+Adafruit invests time and resources providing this open source code,
+please support Adafruit and open-source hardware by purchasing
 products from Adafruit!
 
-Written by Limor Fried/Ladyada  for Adafruit Industries.  
+Written by Limor Fried/Ladyada  for Adafruit Industries.
 BSD license, check license.txt for more information
 All text above, and the splash screen must be included in any redistribution
 *********************************************************************/
@@ -27,6 +27,9 @@ All text above, and the splash screen must be included in any redistribution
 #ifdef __SAM3X8E__
  typedef volatile RwReg PortReg;
  typedef uint32_t PortMask;
+#elif defined (__ESP8266_EX__)
+ typedef volatile GPIO_REG_TYPE PortReg;
+ typedef GPIO_REG_TYPE PortMask;
 #else
   typedef volatile uint8_t PortReg;
   typedef uint8_t PortMask;

--- a/sming/sming/core/pins_arduino.h
+++ b/sming/sming/core/pins_arduino.h
@@ -18,23 +18,23 @@
 #define PB 2
 #define PC 3
 
-#define GPIO_REG_TYPE uint8_t
+#define GPIO_REG_TYPE uint32_t
 
 // We use maximum compatibility to standard Arduino logic.
 
 // Conversion disabled for now
 #define digitalPinToTimer(P) ( NOT_ON_TIMER )
 
-#define digitalPinToPort(P) ( P < 0 ? NOT_A_PIN : ( (int)P < 8 ? PA : ( (int)P < 16 ? PB : ( (int)P == 16 ? PC : NOT_A_PIN ) ) ) )
-#define digitalPinToBitMask(P) ( (int)P < 8 ? _BV((int)P) : ( P < 16 ? _BV( (int)P-8 ) : 1) )
+#define digitalPinToPort(P) ( P < 0 ? NOT_A_PIN : ( (int)P < 8 ? PA : ( (int)P < 16 ? PB : ( (int)P == 16 ? PC : NOT_A_PORT ) ) ) )
+#define digitalPinToBitMask(P) ( (int)P < 16 ? _BV((int)P) : 1 )
 
 #define STD_GPIO_OUT (PERIPHS_GPIO_BASEADDR + GPIO_OUT_ADDRESS)
 #define STD_GPIO_IN (PERIPHS_GPIO_BASEADDR + GPIO_IN_ADDRESS)
 #define STD_GPIO_ENABLE (PERIPHS_GPIO_BASEADDR + GPIO_ENABLE_ADDRESS)
 
-#define portOutputRegister(P) ( ((volatile uint8_t*)(P != PC ? STD_GPIO_OUT : RTC_GPIO_OUT)) + ( ( ((int)P) == PB ) ? 1 : 0) )
-#define portInputRegister(P)  ( ((volatile uint8_t*)(P != PC ? STD_GPIO_IN : RTC_GPIO_IN_DATA)) + ( ( ((int)P) == PB ) ? 1 : 0) )
-#define portModeRegister(P)	  ( ((volatile uint8_t*)(P != PC ? STD_GPIO_ENABLE : RTC_GPIO_ENABLE)) + ( ( ((int)P) == PB ) ? 1 : 0) ) // Stored bits: 0=In, 1=Out
+#define portOutputRegister(P) ((volatile GPIO_REG_TYPE*)(P != PC ? STD_GPIO_OUT : RTC_GPIO_OUT))
+#define portInputRegister(P)  ((volatile GPIO_REG_TYPE*)(P != PC ? STD_GPIO_IN : RTC_GPIO_IN_DATA))
+#define portModeRegister(P)	  ((volatile GPIO_REG_TYPE*)(P != PC ? STD_GPIO_ENABLE : RTC_GPIO_ENABLE)) // Stored bits: 0=In, 1=Out
 
 
 #endif /* WIRING_PINS_ARDUINO_H_ */


### PR DESCRIPTION
PA and PB should be mapped to the same register, and the GPIO registers are 32 bits wide (see documentation here : http://bbs.espressif.com/viewtopic.php?f=7&t=28)
