### PR TITLE
add make terminal option

### DIFF
--- a/sming/Makefile-project.mk
+++ b/sming/Makefile-project.mk
@@ -354,6 +354,11 @@ else
 endif
 	$(TERMINAL)
 
+terminal:
+	$(vecho) "Killing Terminal to free $(COM_PORT)"
+	-$(Q) $(KILL_TERM)
+	$(TERMINAL)
+
 flashinit:
 	$(vecho) "Flash init data default and blank data."
 	$(ESPTOOL) -p $(COM_PORT) -b $(COM_SPEED_ESPTOOL) write_flash $(flashimageoptions) 0x7c000 $(SDK_BASE)/bin/esp_init_data_default.bin 0x7e000 $(SDK_BASE)/bin/blank.bin 0x4B000 $(SMING_HOME)/compiler/data/blankfs.bin


### PR DESCRIPTION
sometimes it's useful to be able to start the serial port monitor
without having to remember what com port or baud rate you've configured
for this project. this adds a simple makefile target that just kills &
starts the terminal in the same way make flash does, without flashing or
resetting the mcu.
