### PR TITLE
make COM_SPEED_SERIAL from Makefile available inside apps

### DIFF
--- a/sming/Makefile
+++ b/sming/Makefile
@@ -62,7 +62,7 @@ LIBS = microc gcc hal phy pp net80211 wpa crypto main freertos lwip minic pwm
 
 # compiler flags using during compilation of source files
 #CFLAGS = -g -save-temps -Os -Wpointer-arith -Wundef -Werror -Wl,-EL -fno-inline-functions -nostdlib -mlongcalls -mtext-section-literals -mno-serialize-volatile -D__ets__ -DICACHE_FLASH
-CFLAGS = -Os -g -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections -D__ets__ -DICACHE_FLASH -DARDUINO=106 $(USER_CFLAGS)
+CFLAGS = -Os -g -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections -D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL) $(USER_CFLAGS)
 
 WIFI_SSID ?= ""
 WIFI_PWD ?= ""

--- a/sming/Makefile-project.mk
+++ b/sming/Makefile-project.mk
@@ -159,7 +159,7 @@ USER_LIBDIR = $(SMING_HOME)/compiler/lib/
 LIBS		= microc gcc hal phy pp net80211 wpa crypto main freertos lwip minic pwm smartconfig sming
 
 # compiler flags using during compilation of source files
-CFLAGS		= -Os -g -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections -D__ets__ -DICACHE_FLASH -DARDUINO=106 $(USER_CFLAGS)
+CFLAGS		= -Os -g -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections -D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL) $(USER_CFLAGS)
 CXXFLAGS	= $(CFLAGS) -fno-rtti -fno-exceptions -std=c++11 -felide-constructors -Wno-literal-suffix
 
 # we will use global WiFi settings from Eclipse Environment Variables, if possible

--- a/sming/Makefile-rboot.mk
+++ b/sming/Makefile-rboot.mk
@@ -153,7 +153,7 @@ EXTRA_INCDIR += $(SDK_BASE)/include/espressif
 
 
 # compiler flags using during compilation of source files
-CFLAGS		= -Os -g -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections -D__ets__ -DICACHE_FLASH -DARDUINO=106 $(USER_CFLAGS)
+CFLAGS		= -Os -g -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections -D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL) $(USER_CFLAGS)
 CXXFLAGS	= $(CFLAGS) -fno-rtti -fno-exceptions -std=c++11 -felide-constructors -Wno-literal-suffix
 
 # libmain must be modified for rBoot big flash support (just one symbol gets weakened)


### PR DESCRIPTION
the Makefiles define COM_SPEED_SERIAL and uses this to start the
terminal, but this value isn't passed to the code. inside user_config.h
there is SERIAL_BAUD_RATE that configures the port speed. this means
it's left up to the user to keep the two in sync, which is less than
ideal. this commit passes COM_SPEED_SERIAL to gcc as a define, and
allows users to use one value for both if they chooseto do so. this
won't break any existing code.
