### PR TITLE
Add default implementation for user_rf_cal_sector_set()

### DIFF
--- a/sming/sming/appinit/user_main.cpp
+++ b/sming/sming/appinit/user_main.cpp
@@ -24,3 +24,37 @@ extern "C" void __attribute__((weak)) user_rf_pre_init(void)
         ptr_reg_rtc_ram[30] &= 0;
     }
 }
+
+extern "C" uint32 ICACHE_FLASH_ATTR
+user_rf_cal_sector_set(void)
+{
+    flash_size_map size_map = system_get_flash_size_map();
+    uint32 rf_cal_sec = 0;
+
+    switch (size_map) {
+        case FLASH_SIZE_4M_MAP_256_256:
+            rf_cal_sec = 128 - 5;
+            break;
+
+        case FLASH_SIZE_8M_MAP_512_512:
+            rf_cal_sec = 256 - 5;
+            break;
+
+        case FLASH_SIZE_16M_MAP_512_512:
+        case FLASH_SIZE_16M_MAP_1024_1024:
+            rf_cal_sec = 512 - 5;
+            break;
+
+        case FLASH_SIZE_32M_MAP_512_512:
+        case FLASH_SIZE_32M_MAP_1024_1024:
+            rf_cal_sec = 1024 - 5;
+            break;
+
+        default:
+            rf_cal_sec = 0;
+            break;
+    }
+
+    return rf_cal_sec;
+}
+


### PR DESCRIPTION
I've created this PR for issue #139.

Should I possibly add the weak attribute to the function to be consistent with user_rf_pre_init()?
