### PR TITLE
Use tcp_close to destroy the TCP listening socket.

### DIFF
--- a/sming/sming/network/TcpServer.cpp
+++ b/sming/sming/network/TcpServer.cpp
@@ -60,6 +60,8 @@ TcpServer::TcpServer(TcpClientDataDelegate clientReceiveDataHandler)
 
 TcpServer::~TcpServer()
 {
+	tcp_close(tcp);
+	tcp = NULL;
 }
 
 TcpConnection* TcpServer::createClient(tcp_pcb *clientTcp)


### PR DESCRIPTION
It's an error to call tcp_poll() on a pcb that has been converted to a
listening socket via tcp_listen(), with such calls causing memory corruption.
Call tcp_close to destroy the socket instead in ~TcpServer, and NULL out tcp
to suppress the call to tcp_poll in the base class
(via ~TcpConnection()->TcpConnection::close()->tcp_poll()).